### PR TITLE
Add Docker support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,30 @@
+FROM php:5-apache
+
+##############################################################################
+###	Install PHP extensions from PEAR/PECL:
+###	- MongoDB driver
+###
+### build-essential: needed for PECL to compile
+### php5-dev: needed to provide 'phpize' command
+##############################################################################
+RUN \
+  apt-get update && \
+  DEBIAN_FRONTEND=noninteractive \
+    apt-get -y install \
+      build-essential \
+      php5-dev \
+  && \
+  pecl channel-update pecl.php.net && \
+  pecl install mongo && \
+  rm -vrf /build /tmp/pear && \
+  echo "extension=mongo.so" > /usr/local/etc/php/conf.d/mongo.ini && \
+  DEBIAN_FRONTEND=noninteractive \
+    apt-get -y autoremove --purge \
+      build-essential \
+      php5-dev \
+  && \
+  apt-get autoclean && \
+  apt-get clean && \
+  rm -rf /var/lib/apt/lists/* /var/log/apt/*
+
+ADD ./moadmin.php /var/www/html/index.php


### PR DESCRIPTION
I've also set up an example automated build at https://registry.hub.docker.com/u/pataquets/phpmoadmin/ .
You can do a quick test by running this:

```
$ docker run --rm -it --net=host dockerfile/mongodb # start a localhost-bound MongoDB node

$ docker run --rm -it --net=host -p 80:80 pataquets/phpmoadmin # start a localhost-bound PHPMoA container
```

Navigate to http://localhost . Hit CTRL+C on each terminal to stop the respective container. 
PMoA will see MongoDB because its container shares localhost network stack. To implement Docker best practices, more customizable connection options should be added (e.g. environ vars). 
